### PR TITLE
Fix maximum levels config setting

### DIFF
--- a/src/main/java/slimeknights/toolleveling/config/Config.java
+++ b/src/main/java/slimeknights/toolleveling/config/Config.java
@@ -32,7 +32,7 @@ public class Config extends AbstractConfig {
   }
 
   public static boolean canLevelUp(int currentLevel) {
-    return INSTANCE.configFile.general.maximumLevels < 0 || INSTANCE.configFile.general.maximumLevels >= currentLevel;
+    return INSTANCE.configFile.general.maximumLevels <= 0 || INSTANCE.configFile.general.maximumLevels >= currentLevel;
   }
 
   public static int getBaseToolXP() {


### PR DESCRIPTION
Opposed to the config description, you needed to change the value to `-1` or lower to actually uncap it. This fixes it.
Neglectable change, but since you‘re at it. 🤷‍♂️